### PR TITLE
Changing NativeBinary.setupTask function visibility

### DIFF
--- a/xcode-compat/src/main/kotlin/org/jetbrains/kotlin/xcodecompat/XcodeCompatPlugin.kt
+++ b/xcode-compat/src/main/kotlin/org/jetbrains/kotlin/xcodecompat/XcodeCompatPlugin.kt
@@ -24,7 +24,7 @@ open class KotlinXcodeExtension(private val project: Project) {
         return presets.withType<AbstractKotlinNativeTargetPreset<T>>()[presetName]
     }
 
-    private fun NativeBinary.setupTask() {
+    fun NativeBinary.setupTask() {
         val buildType = NativeBuildType.valueOf(System.getenv("CONFIGURATION")?.toUpperCase()
                 ?: "DEBUG")
         if (this.buildType == buildType) {


### PR DESCRIPTION
This is a proposal to change the `NativeBinary.setupTask` function visibility.
Changing the visibility of this function will enable the possibility to call it from other build processes outside.
 
Now it is not possible to use the `setupFramework` function for some cases since it will automatically find a target and use it, not enabling the possibility to use your own configured target.